### PR TITLE
feat(Makefile): support customizable image prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,12 @@ BINDIR := ./rootfs
 # Legacy support for DEV_REGISTRY, plus new support for DEIS_REGISTRY.
 DEIS_REGISTRY ?= ${DEV_REGISTRY}
 
+IMAGE_PREFIX ?= deis/
+
 # Kubernetes-specific information for RC, Service, and Image.
 RC := manifests/deis-${SHORT_NAME}-rc.yaml
 SVC := manifests/deis-${SHORT_NAME}-service.yaml
-IMAGE := ${DEIS_REGISTRY}/deis/${SHORT_NAME}:${VERSION}
+IMAGE := ${DEIS_REGISTRY}/${IMAGE_PREFIX}${SHORT_NAME}:${VERSION}
 
 all:
 	@echo "Use a Makefile to control top-level building of the project."


### PR DESCRIPTION
This is an idea borrowed from v1.x.

This spares us from things like yesterday when @arschles asked if anyone minded if he pushed an updated `deis/minio` up to quay.io.

Add the following to your `~/.bash_profile` and even when your dev registry is a public registry, you won't be stepping on any toes:

```
IMAGE_PREFIX=your-username/
```
