### PR TITLE
ref(makefile): switch to git tag approach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export GO15VENDOREXPERIMENT=1
 
 # SemVer with build information is defined in the SemVer 2 spec, but Docker
 # doesn't allow +, so we use -.
-VERSION := 0.0.1-$(shell date "+%Y%m%d%H%M%S")
+VERSION := git-$(shell git rev-parse --short HEAD)
 
 # Common flags passed into Go's linker.
 LDFLAGS := "-s -X main.version=${VERSION}"


### PR DESCRIPTION
We have found issues with the time-based approach in that subsequent
`make` targets will fail because the time is unstable. Switching back
to a git-based tagging method works, along with the `imagePullPolicy: Always`
metadata in the helm charts ensures that we're always up to date.
