### PR TITLE
In an environment, DEIS_REGISTRY is typically set to "myregistry.com/".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ LDFLAGS := "-s -X main.version=${VERSION}"
 BINDIR := ./rootfs/bin
 
 # Legacy support for DEV_REGISTRY, plus new support for DEIS_REGISTRY.
-DEIS_REGISTRY ?= ${DEV_REGISTRY}
+DEIS_REGISTRY ?= ${DEV_REGISTRY}/
 
 IMAGE_PREFIX ?= deis/
 
 # Kubernetes-specific information for RC, Service, and Image.
 RC := manifests/deis-${SHORT_NAME}-rc.yaml
 SVC := manifests/deis-${SHORT_NAME}-service.yaml
-IMAGE := ${DEIS_REGISTRY}/${IMAGE_PREFIX}${SHORT_NAME}:${VERSION}
+IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}${SHORT_NAME}:${VERSION}
 
 all:
 	@echo "Use a Makefile to control top-level building of the project."


### PR DESCRIPTION
The slash is important because it allows us to forgo DEIS_REGISTRY
entirely when building an image for DockerHub:

```
DEIS_REGISTRY='' make docker-build
docker build --rm -t deis/workflow-manager:git-6dce196 rootfs
```

PS this is Fisher's idea
